### PR TITLE
patch: add pod security labels to namespace

### DIFF
--- a/infrastructure/longhorn/base/namespace.yaml
+++ b/infrastructure/longhorn/base/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/infrastructure/longhorn/kustomization.yaml
+++ b/infrastructure/longhorn/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 namespace: longhorn
 resources:
   - https://raw.githubusercontent.com/longhorn/longhorn/v1.6.2/deploy/longhorn.yaml
+  - base/namespace.yaml


### PR DESCRIPTION
Add pod security policy labels to longhorn namespace. Pod's couldn't be created due to default policy rules.