### PR TITLE
patch: cnpg argocd application sync options

### DIFF
--- a/applications/cloudnative-pg/application.yaml
+++ b/applications/cloudnative-pg/application.yaml
@@ -18,3 +18,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - Replace=true


### PR DESCRIPTION
The following error is observed when deploying Cloudnative PG using ArgoCD without any syncOptions configured:

`one or more objects failed to apply, reason: CustomResourceDefinition.apiextensions.k8s.io "poolers.postgresql.cnpg.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes. Retrying attempt #5 at 8:19PM.`

Setting syncOptions to Replace=true ensures that ArgoCD uses kubectl replace instead of kubectl create when deploying resources.

See also: [Docs](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#replace-resource-instead-of-applying-changes)