### PR TITLE
fix: use correct env variable names

### DIFF
--- a/infrastructure/secret-management/vault/config/values.yaml
+++ b/infrastructure/secret-management/vault/config/values.yaml
@@ -55,19 +55,19 @@ server:
     VAULT_TLS_KEY: /vault/userconfig/vault-internal-tls/tls.key
 
   extraSecretEnvironmentVars:
-    - envName: VAULT_AZURE_CLIENT_ID
+    - envName: AZURE_CLIENT_ID
       secretName: vault-unseal
       secretKey: client_id
-    - envName: VAULT_AZURE_CLIENT_SECRET
+    - envName: AZURE_CLIENT_SECRET
       secretName: vault-unseal
       secretKey: client_secret
-    - envName: VAULT_AZURE_TENANT_ID
+    - envName: AZURE_TENANT_ID
       secretName: vault-unseal
       secretKey: tenant_id
-    - envName: VAULT_AZURE_KEYVAULT_NAME
+    - envName: VAULT_AZUREKEYVAULT_NAME
       secretName: vault-unseal
       secretKey: vault_name
-    - envName: VAULT_AZURE_KEYVAULT_KEY_NAME
+    - envName: VAULT_AZUREKEYVAULT_KEY_NAME
       secretName: vault-unseal
       secretKey: vault_key
 
@@ -108,11 +108,11 @@ server:
         }
 
         seal "azurekeyvault" {
-          client_id       = "${VAULT_AZURE_CLIENT_ID}"
-          client_secret   = "${VAULT_AZURE_CLIENT_SECRET}"
-          tenant_id       = "${VAULT_AZURE_TENANT_ID}"
-          vault_name      = "${VAULT_AZURE_KEYVAULT_NAME}"
-          key_name        = "${VAULT_AZURE_KEYVAULT_KEY_NAME}"
+          client_id       = "${AZURE_CLIENT_ID}"
+          client_secret   = "${AZURE_CLIENT_SECRET}"
+          tenant_id       = "${AZURE_TENANT_ID}"
+          vault_name      = "${VAULT_AZUREKEYVAULT_NAME}"
+          key_name        = "${VAULT_AZUREKEYVAULT_KEY_NAME}"
         }
 
         storage "raft" {


### PR DESCRIPTION
- Issue with Vault not being able to get the correct tenantID. Renamed the environment variables