### PR TITLE
patch: fixed some path issues

### DIFF
--- a/kubernetes/apps/core/argocd/kustomization.yaml
+++ b/kubernetes/apps/core/argocd/kustomization.yaml
@@ -6,8 +6,9 @@ resources:
   - https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.2/manifests/install.yaml
   - base/gateway.yaml
   - base/namespace.yaml
-  - ../../argocd/projects/applications.yaml
+  - ../../argocd/projects/core.yaml
   - ../../argocd/projects/infrastructure.yaml
+  - ../../argocd/projects/workloads.yaml
   - ../../argocd/repositories/k8s-gitops.yaml
 
 patches:

--- a/kubernetes/argocd/applications/longhorn.yaml
+++ b/kubernetes/argocd/applications/longhorn.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: git@github.com/dc-tec/k8s-gitops.git
     targetRevision: main
-    path: infrastructure/longhorn
+    path: kubernetes/apps/infrastructure/longhorn
   destination:
     namespace: longhorn-system
     server: https://kubernetes.default.svc

--- a/kubernetes/argocd/applications/openbao.yaml
+++ b/kubernetes/argocd/applications/openbao.yaml
@@ -6,11 +6,11 @@ metadata:
   labels:
     name: openbao
 spec:
-  project: workload
+  project: workloads
   source:
     repoURL: git@github.com/dc-tec/k8s-gitops.git
     targetRevision: main
-    path: kubernetes/apps/workload/openbao
+    path: kubernetes/apps/workloads/openbao
   destination:
     namespace: openbao-infra
     server: https://kubernetes.default.svc


### PR DESCRIPTION
This pull request includes several changes to the ArgoCD configuration files to update paths and project names for better organization and consistency.

Path updates:

* [`kubernetes/argocd/applications/longhorn.yaml`](diffhunk://#diff-eced064cef79c1b5331e3218d19bc3d1057a54220f05632b31bf1c497ff1adc5L13-R13): Updated the `path` in the `source` section to reflect the new directory structure.
* [`kubernetes/argocd/applications/openbao.yaml`](diffhunk://#diff-4cd31592c21b21f599a75fbb49906b65805c894b396eb68a2ea177ad69063deeL9-R13): Updated the `path` in the `source` section to reflect the new directory structure.

Project name updates:

* [`kubernetes/argocd/applications/openbao.yaml`](diffhunk://#diff-4cd31592c21b21f599a75fbb49906b65805c894b396eb68a2ea177ad69063deeL9-R13): Changed the `project` name from `workload` to `workloads` for consistency.

Resource updates:

* [`kubernetes/apps/core/argocd/kustomization.yaml`](diffhunk://#diff-e0d1b3e58e340212c45e64489a3379d12bb0826604982c88959f6e5903ae2eafL9-R11): Updated resource references to point to the correct project files and added a new resource reference.