### PR TITLE
feat: add openbao auth service account

### DIFF
--- a/kubernetes/apps/workloads/openbao/base/serviceaccount.yaml
+++ b/kubernetes/apps/workloads/openbao/base/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: openbao-auth
+    namespace: default

--- a/kubernetes/apps/workloads/openbao/kustomization.yaml
+++ b/kubernetes/apps/workloads/openbao/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - base/namespace.yaml
   - base/gateway.yaml
   - base/certificate.yaml
+  - base/serviceaccount.yaml
   - config/secrets/pkcs12-secret.yaml
 
 helmCharts:


### PR DESCRIPTION
To allow the Openbao Kubernetes Authentication mechanism we need to create a Service Account that has the ability to access the TokenReview API